### PR TITLE
[Module 2, Task 3] Add dataset formats profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .pytest_cache
 .DS_STORE
+.venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ awscli==1.33.18
 pytest==8.2.2
 minio==7.2.7
 s3fs==0.4.2
+pandas==2.2.2
+tables==3.10.1
+pyarrow==17.0.0

--- a/src/dataset/formats_profiling.py
+++ b/src/dataset/formats_profiling.py
@@ -1,0 +1,83 @@
+import numpy as np
+import pandas as pd
+from utils import time_profile, file_profile
+
+
+def test_csv(data: pd.DataFrame):
+    with file_profile('CSV', '.csv') as file_path:
+        with time_profile('CSV save'):
+            data.to_csv(file_path)
+        with time_profile('CSV read'):
+            pd.read_csv(file_path)
+
+
+def test_json(data: pd.DataFrame):
+    with file_profile('JSON', '.json') as file_path:
+        with time_profile('JSON save'):
+            data.to_json(file_path, orient='records')
+        with time_profile('JSON sead'):
+            pd.read_json(file_path, orient='records')
+
+
+def test_json_lines(data: pd.DataFrame):
+    with file_profile('JSONL', '.jsonl') as file_path:
+        with time_profile('JSONL save'):
+            data.to_json(file_path, orient='records', lines=True)
+        with time_profile('JSONL read'):
+            pd.read_json(file_path, orient='records', lines=True)
+
+
+def test_hdf(data: pd.DataFrame):
+    with file_profile('HDF', '.h5') as file_path:
+        with time_profile('HDF save'):
+            data.to_hdf(file_path, key='data')
+        with time_profile('HDF read'):
+            pd.read_hdf(file_path)
+
+
+def test_pickle(data: pd.DataFrame):
+    with file_profile('Pickle', '.pickle') as file_path:
+        with time_profile('Pickle save'):
+            data.to_pickle(file_path)
+        with time_profile('Pickle read'):
+            pd.read_pickle(file_path)
+
+
+def test_feather(data: pd.DataFrame):
+    with file_profile('Feather', '.feather') as file_path:
+        with time_profile('Feather save'):
+            data.to_feather(file_path)
+        with time_profile('Feather read'):
+            pd.read_feather(file_path)
+
+
+def test_parquet(data: pd.DataFrame):
+    with file_profile('Parquet', '.parquet') as file_path:
+        with time_profile('Parquet save'):
+            data.to_parquet(file_path)
+        with time_profile('Parquet read'):
+            pd.read_parquet(file_path)
+
+
+def test_npy(data: pd.DataFrame):
+    with file_profile('Numpy', '.npy') as file_path:
+        with time_profile('Numpy save'):
+            np.save(file_path, data.to_numpy())
+        with time_profile('Numpy read'):
+            np.load(file_path, allow_pickle=True)
+
+
+def main():
+    data = pd.read_csv('data/fraud-email.csv')
+    test_csv(data)
+    test_json(data)
+    test_json_lines(data)
+    test_hdf(data)
+    test_pickle(data)
+    test_feather(data)
+    test_parquet(data)
+    test_npy(data)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/dataset/utils.py
+++ b/src/dataset/utils.py
@@ -1,0 +1,25 @@
+import os
+import time
+import tempfile
+import contextlib
+
+
+@contextlib.contextmanager
+def time_profile(label=''):
+    start_time = time.time()
+    try:
+        yield start_time
+    finally:
+        elapsed_time = time.time() - start_time
+        print(f'{label} time: {elapsed_time:.6f} seconds')
+
+
+@contextlib.contextmanager
+def file_profile(label='', suffix=''):
+    with tempfile.NamedTemporaryFile('w+', suffix=suffix) as file:
+        file_path = file.name
+        try:
+            yield file_path
+        finally:
+            file_size = os.path.getsize(file_path) / (1024 * 1024)
+            print(f'{label} size: {file_size} MB')


### PR DESCRIPTION
## What
Evaluated different dataset formats in terms of read time, write time, and file size. The results are shown below:

```
CSV save time: 0.138864 seconds
CSV read time: 0.088823 seconds
CSV size: 15.259513854980469 MB

JSON save time: 0.027236 seconds
JSON sead time: 0.028046 seconds
JSON size: 15.51057243347168 MB

JSONL save time: 0.049383 seconds
JSONL read time: 0.035123 seconds
JSONL size: 15.510571479797363 MB

HDF save time: 0.067348 seconds
HDF read time: 0.013372 seconds
HDF size: 14.576950073242188 MB

Pickle save time: 0.004867 seconds
Pickle read time: 0.005216 seconds
Pickle size: 13.475873947143555 MB

Feather save time: 0.054053 seconds
Feather read time: 0.015229 seconds
Feather size: 9.663507461547852 MB

Parquet save time: 0.050041 seconds
Parquet read time: 0.047475 seconds
Parquet size: 9.601970672607422 MB

Numpy save time: 0.004169 seconds
Numpy read time: 0.005551 seconds
Numpy size: 13.407171249389648 MB
```