### PR TITLE
[Module 2, Task 4] Add inference profiling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ s3fs==0.4.2
 pandas==2.2.2
 tables==3.10.1
 pyarrow==17.0.0
+scikit-learn==1.5.1
+ray==2.34.0
+dask==2024.8.1
+distributed==2024.8.1

--- a/src/dataset/inference_profiling.py
+++ b/src/dataset/inference_profiling.py
@@ -1,0 +1,70 @@
+import time
+import numpy as np
+from concurrent.futures import wait, ProcessPoolExecutor, ThreadPoolExecutor
+from dask.distributed import Client
+import ray
+from utils import time_profile
+
+
+class Model:
+    def predict(self, batch):
+        return [(time.sleep(0.0001), 0)[1] for _ in batch]
+
+
+def batch_generator(inputs, batch_size=128):
+    for i in range(0, len(inputs), batch_size):
+        yield inputs[i:i + batch_size]
+
+
+def test_naive_inference(corpus, model):
+    with time_profile('Naive inference'):
+        return [model.predict(batch) for batch in batch_generator(corpus)]
+
+
+def test_process_pool_inference(corpus, model):
+    with time_profile('Process pool inference'):
+        with ProcessPoolExecutor() as executor:
+            futures = wait([executor.submit(model.predict, batch) for batch in batch_generator(corpus)]).done
+            results = [future.result() for future in futures]
+            return results
+            
+
+def test_thread_pool_inference(corpus, model):
+    with time_profile('Thread pool inference'):
+        with ThreadPoolExecutor() as executor:
+            futures = wait([executor.submit(model.predict, batch) for batch in batch_generator(corpus)]).done
+            results = [future.result() for future in futures]
+            return results
+
+
+def test_dusk_inference(corpus, model):
+    client = Client()
+    with time_profile('Dusk inference'):
+        futures = [client.submit(model.predict, batch) for batch in batch_generator(corpus)]
+        results = client.gather(futures)
+        return results
+
+
+def test_ray_inference(corpus, model):
+    @ray.remote
+    def predict_ray(batch):
+        return model.predict(batch)
+    
+    with time_profile('Ray inference'):
+        futures = [predict_ray.remote(batch) for batch in batch_generator(corpus)]
+        results = ray.get(futures)
+        return results
+
+
+def main():
+    model = Model()
+    corpus = np.repeat(0, 100_000)
+    test_naive_inference(corpus, model)
+    test_process_pool_inference(corpus, model)
+    test_thread_pool_inference(corpus, model)
+    test_dusk_inference(corpus, model)
+    test_ray_inference(corpus, model)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What 
Profiled different concurrent processing approaches. For small batch sizes, it's more overhead to create processes or threads. Thread pool executor can be efficient for handling many small jobs, as the overhead of managing threads is lower compared to processes. Dask performs exceptionally well with larger, time-consuming jobs.

Batch size: 1
- Naive inference time: 13.079098 seconds
- Process pool inference time: 8.819218 seconds
- Thread pool inference time: 1.365103 seconds
- Dask inference time: 10.321613 seconds
- Ray inference time: 8.713771 seconds

Batch size: 32
- Naive inference time: 13.025162 seconds
- Process pool inference time: 1.429198 seconds
- Thread pool inference time: 0.760773 seconds
- Dask inference time: 0.311834 seconds
- Ray inference time: 1.896937 seconds

Batch size: 128
- Naive inference time: 12.966765 seconds
- Process pool inference time: 1.434559 seconds
- Thread pool inference time: 0.743229 seconds
- Dask inference time: 0.106835 seconds
- Ray inference time: 1.807252 seconds